### PR TITLE
add gh actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,16 +32,16 @@ jobs:
           username: ${{ secrets.UPBOUND_ROBOT_USR }}
           password: ${{ secrets.UPBOUND_ROBOT_PSW }}
       - name: Build
-        uses: crossplane-contrib/xpkg-action@v0.1.0
+        uses: crossplane-contrib/xpkg-action@v0.2.0
         with:
           channel: stable
           version: current
           command: build configuration -f ${{ github.workspace }} --name package.xpkg --ignore '.github/*,.github/*/*,examples/*,hack/*'
       - name: Push
-        uses: crossplane-contrib/xpkg-action@v0.1.0
+        uses: crossplane-contrib/xpkg-action@v0.2.0
         with:
           command: push configuration -f package.xpkg registry.upbound.io/upbound/platform-ref-azure:${{ steps.tagger.outputs.VERSION_TAG }}
       - name: Push Latest
-        uses: crossplane-contrib/xpkg-action@v0.1.0
+        uses: crossplane-contrib/xpkg-action@v0.2.0
         with:
-          command: push configuration -f package.xpkg registry.upbound.io/upbound/platform-ref-azure
+          command: push configuration -f package.xpkg registry.upbound.io/upbound/platform-ref-awazures

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  workflow_dispatch: {}
+
+env:
+  DOCKER_USR: ${{ secrets.UPBOUND_ROBOT_USR }}
+
+jobs:
+  configuration:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+      # The tagger step uses the same logic in the build submodule to generate package tag
+      # https://github.com/upbound/build/blob/4f64913157a952dbe77cd9e05457d9abe695a1d4/makelib/common.mk#L193
+      - name: Set tag
+        run: echo "::set-output name=VERSION_TAG::$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )"
+        id: tagger
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        if: env.DOCKER_USR != ''
+        with:
+          registry: registry.upbound.io
+          username: ${{ secrets.UPBOUND_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_ROBOT_PSW }}
+      - name: Build
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          channel: stable
+          version: current
+          command: build configuration -f ${{ github.workspace }} --name package.xpkg --ignore '.github/*,.github/*/*,examples/*,hack/*'
+      - name: Push
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: push configuration -f package.xpkg registry.upbound.io/upbound/platform-ref-azure:${{ steps.tagger.outputs.VERSION_TAG }}
+      - name: Push Latest
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: push configuration -f package.xpkg registry.upbound.io/upbound/platform-ref-azure

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,4 +44,4 @@ jobs:
       - name: Push Latest
         uses: crossplane-contrib/xpkg-action@v0.2.0
         with:
-          command: push configuration -f package.xpkg registry.upbound.io/upbound/platform-ref-awazures
+          command: push configuration -f package.xpkg registry.upbound.io/upbound/platform-ref-azure

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,26 @@
+name: Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v0.1.0)'
+        required: true
+      message:
+        description: 'Tag message'
+        required: true
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Create Tag
+        uses: negz/create-tag@v1
+        with:
+          version: ${{ github.event.inputs.version }}
+          message: ${{ github.event.inputs.message }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Added GH actions to repo

Fixes #

I have:

- [ x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ x] Run `make reviewable` to ensure this PR is ready for review.
- [ x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

GH actions not tested in this PR. Copied and modified actions form similar repo.

i’m still unclear where/how the package version is set with the GH ci. I see some 0.2.0 versions in the file, but GCP plarofrm ref is at 0.0.6 and the ci file in that repo has 0.2.0 too.