### PR TITLE
Makefile: do not fail when build submodule is not checked out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PROJECT_REPO := github.com/upbound/$(PROJECT_NAME)
 # images are not architecture-specific. We constrain to one platform to avoid
 # needlessly pushing a multi-arch image.
 PLATFORMS ?= linux_amd64
-include build/makelib/common.mk
+-include build/makelib/common.mk
 
 # ====================================================================================
 # Setup Kubernetes tools


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Otherwise initial `make submodules` fails with

```
make submodules
Makefile:9: build/makelib/common.mk: No such file or directory
make: *** No rule to make target 'build/makelib/common.mk'.  Stop.
```

Signed-off-by: Yury Tsarev <yury@upbound.io>

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
