### PR TITLE
Fix provider-helm dependency

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -38,5 +38,5 @@ spec:
   dependsOn:
     - provider: xpkg.upbound.io/upbound/provider-azure
       version: ">=v0.14.1"
-    - provider: xpkg.upbound.io/crossplane/provider-helm
-      version: ">=v0.11.1"
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-helm
+      version: ">=v0.12.0"


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

provider-helm was moved to a new place

Signed-off-by: Yury Tsarev <yury@upbound.io>


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
```
up xpkg build --name package.xpkg --package-root=package --examples-root=examples
up xpkg push xpkg.upbound.io/upbound/platform-ref-azure-staging:v0.4.1 -f package/package.xpkg
cat examples/configuration.yaml
apiVersion: pkg.crossplane.io/v1
kind: Configuration
metadata:
  name: platform-ref-azure
spec:
  package: xpkg.upbound.io/upbound/platform-ref-azure-staging:v0.4.1
  packagePullSecrets:
    - name: package-pull-secret
k apply -f examples/configuration.yaml
k get xrd | grep azure
xclusters.azure.platformref.upbound.io              True          True      26s
xpostgresqlinstances.azure.platformref.upbound.io   True          True      26s
xnetworks.azure.platformref.upbound.io              True                    26s
xservices.azure.platformref.upbound.io              True                    26s
xaks.azure.platformref.upbound.io                   True                    26s
```