### PR TITLE
Fix annotation name bug

### DIFF
--- a/package/cluster/network/composition.yaml
+++ b/package/cluster/network/composition.yaml
@@ -23,7 +23,7 @@ spec:
             string:
               fmt: "%s-rg"
       - fromFieldPath: spec.id
-        toFieldPath: metadata.annotations[upbound.io/external-name]
+        toFieldPath: metadata.annotations[crossplane.io/external-name]
         transforms:
           - type: string
             string:


### PR DESCRIPTION

### Description of your changes

Apparently appeared during migration to Upbound Official Providers as a side effect of mass replacement `crossplane.io` -> `upbound.io`

As it is a core Crossplane [special annotation](https://docs.crossplane.io/latest/concepts/managed-resources/#hl-4-6), we need to fix it to `crossplane.io`


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
