### PR TITLE
Add App abstraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build.init: $(UP)
 # - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat azure.json)
 uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 	@$(INFO) running automated tests
-	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) $(UPTEST) e2e examples/cluster-claim.yaml,examples/postgres-claim.yaml --setup-script=test/setup.sh --default-timeout=2400 || $(FAIL)
+	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) $(UPTEST) e2e examples/cluster-claim.yaml,examples/postgres-claim.yaml,examples/app-claim.yaml --setup-script=test/setup.sh --default-timeout=2400 || $(FAIL)
 	@$(OK) running automated tests
 
 # This target requires the following environment variables to be set:

--- a/examples/app-claim.yaml
+++ b/examples/app-claim.yaml
@@ -1,0 +1,12 @@
+apiVersion: azure.platformref.upbound.io/v1alpha1
+kind: App
+metadata:
+  name: platform-ref-azure-ghost
+spec:
+  providerConfigRef:
+    name: platform-ref-azure
+  passwordSecretRef:
+    namespace: default
+    name: platform-ref-azure-db-conn
+  writeConnectionSecretToRef:
+    name: platform-ref-azure-app-conn

--- a/examples/app-claim.yaml
+++ b/examples/app-claim.yaml
@@ -3,6 +3,8 @@ kind: App
 metadata:
   name: platform-ref-azure-ghost
   namespace: default
+  annotations:
+    uptest.upbound.io/pre-delete-hook: testhooks/delete-release-app.sh
 spec:
   providerConfigRef:
     name: platform-ref-azure

--- a/examples/app-claim.yaml
+++ b/examples/app-claim.yaml
@@ -2,6 +2,7 @@ apiVersion: azure.platformref.upbound.io/v1alpha1
 kind: App
 metadata:
   name: platform-ref-azure-ghost
+  namespace: default
 spec:
   providerConfigRef:
     name: platform-ref-azure

--- a/examples/cluster-claim.yaml
+++ b/examples/cluster-claim.yaml
@@ -4,7 +4,7 @@ metadata:
   name: platform-ref-azure
   namespace: default
   annotations:
-    uptest.upbound.io/post-assert-hook: testhooks/delete-release.sh
+    uptest.upbound.io/pre-delete-hook: testhooks/delete-release.sh
 spec:
   id: platform-ref-azure
   parameters:

--- a/examples/testhooks/delete-release-app.sh
+++ b/examples/testhooks/delete-release-app.sh
@@ -5,5 +5,5 @@ set -aeuo pipefail
 # Note(turkenh): This is a workaround for the infamous dependency problem during deletion.
 # Note(ytsarev): In addition to helm Release deletion we also need to pause
 # XService reconciler to prevent it from recreating the Release.
-${KUBECTL} annotate --overwrite xservices.azure.platformref.upbound.io --all crossplane.io/paused="true"
-${KUBECTL} delete release -l crossplane.io/claim-name=platform-ref-azure
+${KUBECTL} annotate --overwrite xapps.azure.platformref.upbound.io --all crossplane.io/paused="true"
+${KUBECTL} delete release -l crossplane.io/claim-name=platform-ref-azure-ghost

--- a/examples/testhooks/delete-release.sh
+++ b/examples/testhooks/delete-release.sh
@@ -5,5 +5,5 @@ set -aeuo pipefail
 # Note(turkenh): This is a workaround for the infamous dependency problem during deletion.
 # Note(ytsarev): In addition to helm Release deletion we also need to pause
 # XService reconciler to prevent it from recreating the Release.
-${KUBECTL} annotate xservices.azure.platformref.upbound.io --all crossplane.io/paused="true"
+${KUBECTL} annotate --overwrite xservices.azure.platformref.upbound.io --all crossplane.io/paused="true"
 ${KUBECTL} delete release --all

--- a/package/app/composition.yaml
+++ b/package/app/composition.yaml
@@ -1,0 +1,70 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xapps.azure.platformref.upbound.io
+  labels:
+    provider: helm
+spec:
+  writeConnectionSecretsToNamespace: upbound-system
+  compositeTypeRef:
+    apiVersion: azure.platformref.upbound.io/v1alpha1
+    kind: XApp
+  resources:
+    - name: helmRelease
+      base:
+        apiVersion: helm.crossplane.io/v1beta1
+        kind: Release
+        spec:
+          rollbackLimit: 3
+          forProvider:
+            namespace: ghost
+            chart:
+              name: ghost
+              repository: https://charts.bitnami.com/bitnami
+              version: "19.1.38"
+            values:
+              persistence:
+                enabled: false
+              mysql:
+                enabled: false
+              externalDatabase:
+                database: upbound
+                port: 3306
+              ghostHost: upboundrocks.cloud
+              ghostBlogTitle: Upbound Rocks!
+            set:
+              - name: externalDatabase.host
+                valueFrom:
+                  secretKeyRef:
+                    key: host
+              - name: externalDatabase.user
+                valueFrom:
+                  secretKeyRef:
+                    key: username
+              - name: externalDatabase.password
+                valueFrom:
+                  secretKeyRef:
+                    key: password
+      patches:
+        # All Helm releases derive their labels and annotations from the XR.
+        - fromFieldPath: metadata.labels
+          toFieldPath: metadata.labels
+        - fromFieldPath: metadata.annotations
+          toFieldPath: metadata.annotations
+        # All Helm releases derive the ProviderConfig to use from the XR.
+        - fromFieldPath: spec.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+        - fromFieldPath: spec.helm.chart.version
+          toFieldPath: spec.forProvider.chart.version
+        - fromFieldPath: spec.passwordSecretRef.namespace
+          toFieldPath: spec.forProvider.set[0].valueFrom.secretKeyRef.namespace
+        - fromFieldPath: spec.passwordSecretRef.name
+          toFieldPath: spec.forProvider.set[0].valueFrom.secretKeyRef.name
+        - fromFieldPath: spec.passwordSecretRef.namespace
+          toFieldPath: spec.forProvider.set[1].valueFrom.secretKeyRef.namespace
+        - fromFieldPath: spec.passwordSecretRef.name
+          toFieldPath: spec.forProvider.set[1].valueFrom.secretKeyRef.name
+        - fromFieldPath: spec.passwordSecretRef.namespace
+          toFieldPath: spec.forProvider.set[2].valueFrom.secretKeyRef.namespace
+        - fromFieldPath: spec.passwordSecretRef.name
+          toFieldPath: spec.forProvider.set[2].valueFrom.secretKeyRef.name

--- a/package/app/definition.yaml
+++ b/package/app/definition.yaml
@@ -1,0 +1,65 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xapps.azure.platformref.upbound.io
+spec:
+  group: azure.platformref.upbound.io
+  names:
+    kind: XApp
+    plural: xapps
+  claimNames:
+    kind: App
+    plural: apps
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              helm:
+               type: object
+               description: Configuration for operators.
+               properties:
+                 chart:
+                   type: object
+                   description: Configuration for the Helm Chart
+                   properties:
+                     name:
+                       type: string
+                       description: chart name
+                     repo:
+                       type: string
+                       description: chart repo
+                     version:
+                       type: string
+                       description: chart version
+              passwordSecretRef:
+                type: object
+                description: "A reference to the Secret object containing database credentials"
+                properties:
+                  namespace:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - namespace
+                - name
+              providerConfigRef:
+                type: object
+                description: "A reference to the ProviderConfig of the cluster that services should
+                be deployed to."
+                properties:
+                  name:
+                    type: string
+                    description: "Name of the Helm provider configuration.
+                      This will typically be the name of the cluster with a
+                      five character suffix appended."
+                required:
+                - name
+            required:
+            - providerConfigRef

--- a/package/cluster/composition.yaml
+++ b/package/cluster/composition.yaml
@@ -3,6 +3,7 @@ kind: Composition
 metadata:
   name: xclusters.azure.platformref.upbound.io
 spec:
+  writeConnectionSecretsToNamespace: upbound-system
   compositeTypeRef:
     apiVersion: azure.platformref.upbound.io/v1alpha1
     kind: XCluster
@@ -23,7 +24,7 @@ spec:
           toFieldPath: spec.id
         - fromFieldPath: spec.id
           toFieldPath: spec.writeConnectionSecretToRef.name
-        - fromFieldPath: spec.claimRef.namespace
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
           toFieldPath: spec.writeConnectionSecretToRef.namespace
         - fromFieldPath: spec.parameters.nodes.count
           toFieldPath: spec.parameters.nodes.count

--- a/package/database/postgres/composition.yaml
+++ b/package/database/postgres/composition.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     provider: azure
 spec:
+  writeConnectionSecretsToNamespace: upbound-system
   compositeTypeRef:
     apiVersion: azure.platformref.upbound.io/v1alpha1
     kind: XPostgreSQLInstance
@@ -32,9 +33,9 @@ spec:
         - type: string
           string:
             fmt: "%s-postgresql"
-    - fromFieldPath: spec.claimRef.namespace
+    - fromFieldPath: spec.writeConnectionSecretToRef.namespace
       toFieldPath: spec.writeConnectionSecretToRef.namespace
-    - fromFieldPath: spec.parameters.clusterRef.id
+    - fromFieldPath: metadata.uid
       toFieldPath: spec.writeConnectionSecretToRef.name
       transforms:
       - type: string
@@ -55,10 +56,18 @@ spec:
     - fromFieldPath: spec.parameters.passwordSecretRef.key
       toFieldPath: spec.forProvider.administratorLoginPasswordSecretRef.key
     connectionDetails:
-        - fromConnectionSecretKey: username
-        - fromConnectionSecretKey: password
-        - fromConnectionSecretKey: endpoint
-        - fromConnectionSecretKey: port
+    - type: FromFieldPath
+      name: host
+      fromFieldPath: status.atProvider.fqdn
+    - type: FromConnectionSecretKey
+      name: username
+      fromConnectionSecretKey: username
+    - type: FromConnectionSecretKey
+      name: password
+      fromConnectionSecretKey: password
+    - type: FromConnectionSecretKey
+      name: port
+      fromConnectionSecretKey: port
   # db-server vnet-rule for subnet where AKS lives in
   - name: vnetrule
     base:

--- a/package/database/postgres/definition.yaml
+++ b/package/database/postgres/definition.yaml
@@ -11,11 +11,10 @@ spec:
     kind: PostgreSQLInstance
     plural: postgresqlinstances
   connectionSecretKeys:
-    - hostname
-    - port
-    - database
     - username
     - password
+    - port
+    - host
   versions:
   - name: v1alpha1
     served: true


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Fix and align connection secret propagation of Cluster and Database
* Add App abstraction symmetric to platform-ref-aws
* Add App Claim to uptest make target

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
k get claim
NAME                                                                    SYNCED   READY   CONNECTION-SECRET            AGE
postgresqlinstance.azure.platformref.upbound.io/platform-ref-azure-db   True     True    platform-ref-azure-db-conn   52m

NAME                                                        SYNCED   READY   CONNECTION-SECRET             AGE
app.azure.platformref.upbound.io/platform-ref-azure-ghost   True     True    platform-ref-azure-app-conn   15m

NAME                                                      SYNCED   READY   CONNECTION-SECRET               AGE
cluster.azure.platformref.upbound.io/platform-ref-azure   True     True    platform-ref-azure-kubeconfig   55m
```