### PR TITLE
Extend XCluster abstraction with bi-directional patching

### DIFF
--- a/package/cluster/aks/composition.yaml
+++ b/package/cluster/aks/composition.yaml
@@ -23,6 +23,9 @@ spec:
                 vmSize: Standard_B2s #patched
             identity:
               - type: "SystemAssigned"
+            apiServerAccessProfile:
+              - authorizedIpRanges:
+                  - 0.0.0.0/0
       patches:
         - fromFieldPath: spec.id
           toFieldPath: metadata.name
@@ -54,6 +57,8 @@ spec:
             - type: string
               string:
                 fmt: "%s-aks"
+        - fromFieldPath: spec.parameters.authorizedIpRange
+          toFieldPath: spec.forProvider.apiServerAccessProfile[0].authorizedIpRanges[0]
       connectionDetails:
         - fromConnectionSecretKey: kubeconfig
     - name: provider-config-helm

--- a/package/cluster/aks/definition.yaml
+++ b/package/cluster/aks/definition.yaml
@@ -27,6 +27,8 @@ spec:
                 type: object
                 description: AKS configuration parameters.
                 properties:
+                  authorizedIpRange:
+                    type: string
                   nodes:
                     type: object
                     description: AKS node configuration parameters.

--- a/package/cluster/composition.yaml
+++ b/package/cluster/composition.yaml
@@ -14,6 +14,11 @@ spec:
       patches:
         - fromFieldPath: spec.id
           toFieldPath: spec.id
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.subnetCIDR
+          toFieldPath: status.authorizedIpRange
+          policy:
+            fromFieldPath: Required
     - base:
         apiVersion: azure.platformref.upbound.io/v1alpha1
         kind: XAKS
@@ -30,6 +35,10 @@ spec:
           toFieldPath: spec.parameters.nodes.count
         - fromFieldPath: spec.parameters.nodes.size
           toFieldPath: spec.parameters.nodes.size
+        - fromFieldPath: status.authorizedIpRange
+          toFieldPath: spec.parameters.authorizedIpRange
+          policy:
+            fromFieldPath: Required
     - base:
         apiVersion: azure.platformref.upbound.io/v1alpha1
         kind: XServices

--- a/package/cluster/definition.yaml
+++ b/package/cluster/definition.yaml
@@ -67,3 +67,8 @@ spec:
             required:
             - id
             - parameters
+          status:
+            type: object
+            properties:
+              authorizedIpRange:
+                type: string

--- a/package/cluster/network/composition.yaml
+++ b/package/cluster/network/composition.yaml
@@ -74,3 +74,9 @@ spec:
             - type: string
               string:
                 fmt: "%s-sn"
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.subnetId
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.addressPrefixes[0]
+          toFieldPath: status.subnetCIDR

--- a/package/cluster/network/definition.yaml
+++ b/package/cluster/network/definition.yaml
@@ -23,3 +23,10 @@ spec:
                   description: ID of this Network that other objects will use to refer to it.
               required:
                 - id
+            status:
+              type: object
+              properties:
+                subnetId:
+                  type: string
+                subnetCIDR:
+                  type: string


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Extend XCluster abstraction with the reference case of bi-directional patching.

Depends on https://github.com/upbound/provider-azure/pull/462

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
k get xaks
NAME                             SYNCED   READY   COMPOSITION                         AGE
platform-ref-azure-dkkwk-fm4g6   True     True    xaks.azure.platformref.upbound.io   31m
```
