### PR TITLE
Remove direct dependency on provider

### DIFF
--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -36,9 +36,6 @@ spec:
   crossplane:
     version: ">=v1.14.1-0"
   dependsOn:
-    - provider: xpkg.upbound.io/upbound/provider-azure-containerservice
-      # renovate: datasource=github-releases depName=upbound/provider-azure
-      version: "v0.42.1"
     - configuration: xpkg.upbound.io/upbound/configuration-azure-network
       # renovate: datasource=github-releases depName=upbound/configuration-azure-network
       version: "v0.8.0"


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

There is no need to specify direct provider-azure-containerservice dependency as it comes from configuration-azure-aks utilizing Configuration of Configurations pattern

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Uptest below
